### PR TITLE
Feature/dynamic chain endpoint

### DIFF
--- a/algorithm_toolkit/__init__.py
+++ b/algorithm_toolkit/__init__.py
@@ -48,7 +48,7 @@ app.config['CORS_ORIGIN_WHITELIST'].append('https://mytiledriver.com')
 app.config['CORS_ORIGIN_WHITELIST'].append('https://tdprocess.com')
 app.config['TILEDRIVER_URL'] = 'https://app.tiledriver.com/'
 
-from .views.home import home, main, chain_run_status
+from .views.home import home, main, api_chain, chain_run_status
 from .views.manage import manage
 
 app.register_blueprint(home)
@@ -58,6 +58,7 @@ app.jinja_loader.searchpath.insert(0, app.config['ATK_PATH'] + '/templates')
 
 csrf = CSRFProtect(app)
 csrf.exempt(main)
+csrf.exempt(api_chain)
 csrf.exempt(chain_run_status)
 
 

--- a/algorithm_toolkit/__init__.py
+++ b/algorithm_toolkit/__init__.py
@@ -48,7 +48,7 @@ app.config['CORS_ORIGIN_WHITELIST'].append('https://mytiledriver.com')
 app.config['CORS_ORIGIN_WHITELIST'].append('https://tdprocess.com')
 app.config['TILEDRIVER_URL'] = 'https://app.tiledriver.com/'
 
-from .views.home import home, main, api_chain, chain_run_status
+from .views.home import home, main, run_chain, chain_run_status
 from .views.manage import manage
 
 app.register_blueprint(home)
@@ -58,7 +58,7 @@ app.jinja_loader.searchpath.insert(0, app.config['ATK_PATH'] + '/templates')
 
 csrf = CSRFProtect(app)
 csrf.exempt(main)
-csrf.exempt(api_chain)
+csrf.exempt(run_chain)
 csrf.exempt(chain_run_status)
 
 

--- a/algorithm_toolkit/templates/test_run.html
+++ b/algorithm_toolkit/templates/test_run.html
@@ -270,7 +270,7 @@
         }
 
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', thisProtocol + '//' + thisHost + '/main/', true);
+        xhr.open('POST', thisProtocol + '//' + thisHost + '/' + 'api' + '/' + '{{ chain_name }}' + '/', true);
         xhr.setRequestHeader("X-CSRFToken", csrf_token);
         xhr.onload = function(evt) {
             var error = false;

--- a/algorithm_toolkit/templates/test_run.html
+++ b/algorithm_toolkit/templates/test_run.html
@@ -270,7 +270,7 @@
         }
 
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', thisProtocol + '//' + thisHost + '/' + 'api' + '/' + '{{ chain_name }}' + '/', true);
+        xhr.open('POST', thisProtocol + '//' + thisHost + '/' + 'chains' + '/' + '{{ chain_name }}' + '/', true);
         xhr.setRequestHeader("X-CSRFToken", csrf_token);
         xhr.onload = function(evt) {
             var error = false;

--- a/algorithm_toolkit/utils/home_utils.py
+++ b/algorithm_toolkit/utils/home_utils.py
@@ -1,0 +1,82 @@
+import requests
+import json
+
+from flask import make_response
+
+from .data_utils import create_random_string
+from .file_utils import get_chain_def
+
+
+def chain_check(request, chain_name, path):
+
+    chain = None
+    status_key = None
+    run_mode = None
+    iter_param = None
+    iter_type = None
+    iter_value = None
+
+    if request.method == 'POST':
+        try:
+            chain = request.form['chain']
+        except KeyError:
+            chain = None
+
+        try:
+            status_key = request.form['status_key']
+        except KeyError:
+            status_key = None
+
+        if 'run_mode' in request.form:
+            if request.form['run_mode'] == 'batch':
+                try:
+                    run_mode = 'batch'
+                    iter_param = request.form['iter_param']
+                    iter_type = request.form['iter_type']
+                    iter_value = request.form['iter_value']
+                except KeyError:
+                    return make_response('Batch mode misconfigured', 400)
+            else:
+                run_mode = 'single'
+        else:
+            run_mode = 'single'
+    elif request.method == 'GET':  # pragma: no branch
+        chain = request.args.get('chain', None)
+        status_key = request.args.get('status_key', None)
+        run_mode = request.args.get('run_mode', 'single')
+        iter_param = request.args.get('iter_param', None)
+        iter_type = request.args.get('iter_type', None)
+        iter_value = request.args.get('iter_value', None)
+
+    if status_key is None:
+        status_key = create_random_string(http_safe=True)
+
+    if chain is None:
+        return make_response('Missing chain parameter in request', 400)
+
+    if chain.lower() == 'from_global':
+        try:
+            chain = app.config['CHAIN_DATA'].pop(status_key)
+        except ValueError:
+            return make_response(
+                'Chain parameter not present in app configuration', 400)
+    else:
+        try:
+            chain = json.loads(chain)
+        except ValueError:
+            return make_response('Chain parameter not properly formatted', 400)
+
+    if chain_name not in get_chain_def(path):
+        return make_response('Chain name does not exist', 400)
+
+    if 'algorithms' not in chain:
+        return make_response('Algorithms not defined', 400)
+
+    return ({
+        'chain': chain,
+        'status_key': status_key,
+        'run_mode': run_mode,
+        'iter_param': iter_param,
+        'iter_type': iter_type,
+        'iter_val': iter_value
+    })

--- a/algorithm_toolkit/views/home.py
+++ b/algorithm_toolkit/views/home.py
@@ -40,6 +40,7 @@ from ..utils.file_utils import (
     list_algorithms
 )
 from ..utils.data_utils import create_random_string
+from ..utils.home_utils import chain_check
 from cli.cli import do_uninstall
 
 from . import home
@@ -131,106 +132,123 @@ def show_docs(filename):
     return send_from_directory(docs_path, filename)
 
 
+# Chain name not in the request form, but in the endpoint!
+# New namespace ( /api/ ) added to prevent user from envoking other static routes
+@home.route('/api/<chain_name>/', methods=['POST', 'GET'])
+@cross_origin(origins=cors_origins)
+@check_api_key(request, api_key)
+def api_chain(chain_name):
+    # Returns a dictionary or a bad request
+    check = chain_check(request, chain_name, path)
+
+    if isinstance(check, dict):  # If check is a dict
+        chain = check['chain']
+        chain['chain_name'] = chain_name
+        status_key = check['status_key']
+        run_mode = check['run_mode']
+        iter_param = check['iter_param']
+        iter_type = check['iter_type']
+        iter_val = check['iter_val']
+
+        c_obj = AlgorithmChain(path, chain)
+        if c_obj.chain_definition == {}:
+            return make_response('Chain name not found', 404)
+        cl = c_obj.create_ledger(status_key)
+        cl.make_working_folders()
+
+        if run_mode == 'single':
+            response = c_obj.call_chain_algorithms()
+            save_fname = status_key + '.json'
+
+            if 'CHAIN_LEDGER_HISTORY_PATH' in app.config:
+                save_path = os.path.join(
+                    app.config['CHAIN_LEDGER_HISTORY_PATH'], save_fname)
+            else:
+                make_dir_if_not_exists(os.path.join(path, 'history'))
+                save_path = os.path.join(path, 'history', save_fname)
+            c_obj.chain_ledger.save_history_to_json(save_path, pretty=True)
+
+            if 'CHAIN_HISTORY' in app.config:
+                if app.config['CHAIN_HISTORY_LENGTH'] > 0:
+                    ch = app.config['CHAIN_HISTORY']
+
+                    if len(ch) > app.config['CHAIN_HISTORY_LENGTH']:
+                        ch.popitem(last=False)
+
+                    ch[status_key] = c_obj.chain_ledger
+        else:
+            response = c_obj.call_batch(iter_param, iter_type, iter_value)
+
+        cl.remove_working_folders()
+
+        if response['output_type'] == 'error':
+            return make_response(jsonify(response), 400)
+
+    else:  # If check not a dict, then it must be a bad request!
+        return check
+
+    return jsonify(response)
+
+
+# This route/function is depricated ( Replaced by execute_chain() )
+# Chain name expected in the request form
 @home.route('/main/', methods=['POST', 'GET'])
 @cross_origin(origins=cors_origins)
 @check_api_key(request, api_key)
 def main():
-    chain = None
-    status_key = None
-    run_mode = None
-    iter_param = None
-    iter_type = None
-    iter_value = None
+    try:
+        chain_name = json.loads(request.form['chain'])['chain_name']
+    except:
+        return make_response('Chain name does not exist in request form', 400)
 
-    if request.method == 'POST':
-        try:
-            chain = request.form['chain']
-        except KeyError:
-            chain = None
+    # Returns a dictionary or a response
+    check = chain_check(request, chain_name, path)
 
-        try:
-            status_key = request.form['status_key']
-        except KeyError:
-            status_key = None
+    if isinstance(check, dict):  # If check is a dict
 
-        if 'run_mode' in request.form:
-            if request.form['run_mode'] == 'batch':
-                try:
-                    run_mode = 'batch'
-                    iter_param = request.form['iter_param']
-                    iter_type = request.form['iter_type']
-                    iter_value = request.form['iter_value']
-                except KeyError:
-                    return make_response('Batch mode misconfigured', 400)
+        chain = check['chain']
+        status_key = check['status_key']
+        run_mode = check['run_mode']
+        iter_param = check['iter_param']
+        iter_type = check['iter_type']
+        iter_val = check['iter_val']
+
+        c_obj = AlgorithmChain(path, chain)
+        if c_obj.chain_definition == {}:
+            return make_response('Chain name not found', 404)
+        cl = c_obj.create_ledger(status_key)
+        cl.make_working_folders()
+
+        if run_mode == 'single':
+            response = c_obj.call_chain_algorithms()
+            save_fname = status_key + '.json'
+
+            if 'CHAIN_LEDGER_HISTORY_PATH' in app.config:
+                save_path = os.path.join(
+                    app.config['CHAIN_LEDGER_HISTORY_PATH'], save_fname)
             else:
-                run_mode = 'single'
+                make_dir_if_not_exists(os.path.join(path, 'history'))
+                save_path = os.path.join(path, 'history', save_fname)
+            c_obj.chain_ledger.save_history_to_json(save_path, pretty=True)
+
+            if 'CHAIN_HISTORY' in app.config:
+                if app.config['CHAIN_HISTORY_LENGTH'] > 0:
+                    ch = app.config['CHAIN_HISTORY']
+
+                    if len(ch) > app.config['CHAIN_HISTORY_LENGTH']:
+                        ch.popitem(last=False)
+
+                    ch[status_key] = c_obj.chain_ledger
         else:
-            run_mode = 'single'
-    elif request.method == 'GET':  # pragma: no branch
-        chain = request.args.get('chain', None)
-        status_key = request.args.get('status_key', None)
-        run_mode = request.args.get('run_mode', 'single')
-        iter_param = request.args.get('iter_param', None)
-        iter_type = request.args.get('iter_type', None)
-        iter_value = request.args.get('iter_value', None)
+            response = c_obj.call_batch(iter_param, iter_type, iter_value)
 
-    if status_key is None:
-        status_key = create_random_string(http_safe=True)
+        cl.remove_working_folders()
 
-    if chain is None:
-        return make_response('Missing chain parameter in request', 400)
+        if response['output_type'] == 'error':
+            return make_response(jsonify(response), 400)
 
-    if chain.lower() == 'from_global':
-        try:
-            chain = app.config['CHAIN_DATA'].pop(status_key)
-        except ValueError:
-            return make_response(
-                'Chain parameter not present in app configuration', 400)
-    else:
-        try:
-            chain = json.loads(chain)
-        except ValueError:
-            return make_response('Chain parameter not properly formatted', 400)
-
-    if 'chain_name' not in chain:
-        return make_response('Chain name not defined', 400)
-
-    if 'algorithms' not in chain:
-        return make_response('Algorithms not defined', 400)
-
-    c_obj = AlgorithmChain(path, chain)
-    if c_obj.chain_definition == {}:
-        return make_response('Chain name not found', 404)
-    cl = c_obj.create_ledger(status_key)
-    cl.make_working_folders()
-
-    if run_mode == 'single':
-        response = c_obj.call_chain_algorithms()
-        save_fname = status_key + '.json'
-
-        if 'CHAIN_LEDGER_HISTORY_PATH' in app.config:
-            save_path = os.path.join(
-                app.config['CHAIN_LEDGER_HISTORY_PATH'], save_fname)
-        else:
-            make_dir_if_not_exists(os.path.join(path, 'history'))
-            save_path = os.path.join(path, 'history', save_fname)
-        c_obj.chain_ledger.save_history_to_json(save_path, pretty=True)
-
-        if 'CHAIN_HISTORY' in app.config:
-            if app.config['CHAIN_HISTORY_LENGTH'] > 0:
-                ch = app.config['CHAIN_HISTORY']
-
-                if len(ch) > app.config['CHAIN_HISTORY_LENGTH']:
-                    ch.popitem(last=False)
-
-                ch[status_key] = c_obj.chain_ledger
-    else:
-        response = c_obj.call_batch(iter_param, iter_type, iter_value)
-
-    cl.remove_working_folders()
-
-    if response['output_type'] == 'error':
-        return make_response(jsonify(response), 400)
+    else:  # If check not a dict, then it must be a response!
+        return check
 
     return jsonify(response)
 
@@ -938,7 +956,6 @@ def test_run(chain_name):
                     pass
             temp_item['parameters'] = temp_params
             temp_input_algorithms.append(temp_item)
-        chain['chain_name'] = chain_name
         chain['algorithms'] = temp_input_algorithms
 
     return render_template(
@@ -947,6 +964,7 @@ def test_run(chain_name):
         a_list=a_list,
         fetching_results=fetching_results,
         chain=chain,
+        chain_name=chain_name,
         chains=get_chain_def(path),
         docs=get_docs_link(),
         nav='test_run'

--- a/algorithm_toolkit/views/home.py
+++ b/algorithm_toolkit/views/home.py
@@ -135,8 +135,8 @@ def show_docs(filename):
 
 
 # Chain name not in the request form, but in the endpoint!
-# New namespace ( /api/ ) added to prevent user from envoking other static routes
-@home.route('/api/<chain_name>/', methods=['POST', 'GET'])
+# New namespace ( /chains/ ) added to prevent user from envoking other static routes
+@home.route('/chains/<chain_name>/', methods=['POST', 'GET'])
 @cross_origin(origins=cors_origins)
 @check_api_key(request, api_key)
 def run_chain(chain_name):

--- a/algorithm_toolkit/views/home.py
+++ b/algorithm_toolkit/views/home.py
@@ -190,7 +190,7 @@ def api_chain(chain_name):
     return jsonify(response)
 
 
-# This route/function is depricated ( Replaced by execute_chain() )
+# This route/function is depricated ( Replaced by api_chain() )
 # Chain name expected in the request form
 @home.route('/main/', methods=['POST', 'GET'])
 @cross_origin(origins=cors_origins)
@@ -201,7 +201,7 @@ def main():
     except:
         return make_response('Chain name does not exist in request form', 400)
 
-    # Returns a dictionary or a response
+    # Returns a dictionary or a bad request
     check = chain_check(request, chain_name, path)
 
     if isinstance(check, dict):  # If check is a dict
@@ -247,7 +247,7 @@ def main():
         if response['output_type'] == 'error':
             return make_response(jsonify(response), 400)
 
-    else:  # If check not a dict, then it must be a response!
+    else:  # If check not a dict, then it must be a bad request!
         return check
 
     return jsonify(response)


### PR DESCRIPTION
## What?
When performing a POST request to run a chain, the endpoint now contains the chain name. The chain is no longer needed in the request form. The old route `/main/`, which requires the chain name in the request form, still exists, but has been deprecated. A utility function was also added.

Issue #21 
## Why?
To reduce the number of parameters in the request form, and to reduce the amount of code in [home.py](https://github.com/BeamIO-Inc/algorithm_toolkit/blob/feature/dynamic-chain-endpoint/algorithm_toolkit/views/home.py)
## How?
Created a new route `/api/<chain_name>` which fires off a nearly identical function that `/main/` did. Also edited the [test_run](https://github.com/BeamIO-Inc/algorithm_toolkit/blob/feature/dynamic-chain-endpoint/algorithm_toolkit/templates/test_run.html) template so that it submits a POST request to the new `/api/<chain_name>` instead of `/main/`. A utility function was also create and used in both route functions, which performs some basic checking logic of the request form. 
## Testing?
Postman was used in order to test the deprecated `/main/` endpoint as well as the new `/api/<chain_name>` endpoint